### PR TITLE
[Bug Fix] Use relative path for setup.js to support subdir hosted servers.

### DIFF
--- a/modules/advancement.js
+++ b/modules/advancement.js
@@ -1,5 +1,5 @@
 import { sortObjArrayByName } from "./setup.js";
-import { enrichTinyMCE } from "/systems/age-system/modules/setup.js";
+import { enrichTinyMCE } from "./setup.js";
 import { ageSystem } from "./config.js";
 
 /**


### PR DESCRIPTION
Discovered this after I deployed my world to production, since I was getting an error about mime-types not matching up in the js console.
After looking through the server logs, I discovered that the advancement.js has a sneaky abosolute path for setup.js, which doesn't work if your foundry instance is hosted in a subdirectory (like mine is in prod).