### PR TITLE
Fix issue with AgeTracker capuring canvas mouse events

### DIFF
--- a/less/age-tracker.less
+++ b/less/age-tracker.less
@@ -3,10 +3,8 @@
 /*******************************/
 
 #age-tracker {
-    position: fixed;
-    height: fit-content;
-    width: 100svw;
-    bottom: 150px;
+    pointer-events: all;
+    margin-bottom: 15px;
     a {
         padding-top: 4px;
         text-shadow: none;

--- a/modules/age-tracker.js
+++ b/modules/age-tracker.js
@@ -9,7 +9,8 @@ export class AgeTracker extends foundry.applications.api.HandlebarsApplicationMi
 			milestone: AgeTracker._milestone
 		},
 		window: {
-			frame: false
+			frame: false,
+			positioned: false
 		}
 	}
 
@@ -19,11 +20,13 @@ export class AgeTracker extends foundry.applications.api.HandlebarsApplicationMi
 		}
 	}
 
-	// _onFirstRender(a, b) {
-	// 	super._onFirstRender(a, b);
-	// 	document.getElementById("ui-bottom").prepend(document.getElementById("age-tracker"));
-	// }
-	
+	/** @param {HTMLElement} element  */
+	_insertElement(element) {
+		const existing = document.getElementById(element.id);
+		if (existing) existing.replaceWith(element);
+		else document.getElementById("ui-bottom").prepend(element);
+	}
+
 	async _prepareContext(options) {
 		const data = super._prepareContext(options);
 		data.isGM = game.user.isGM;

--- a/styles/age-system.css
+++ b/styles/age-system.css
@@ -3953,10 +3953,8 @@
 /**        AGE Tracker        **/
 /*******************************/
 #age-tracker {
-  position: fixed;
-  height: fit-content;
-  width: 100svw;
-  bottom: 150px;
+  pointer-events: all;
+  margin-bottom: 15px;
 }
 #age-tracker a {
   padding-top: 4px;

--- a/system.json
+++ b/system.json
@@ -6,7 +6,7 @@
     "download": "https://github.com/vkdolea/age-system/archive/4.0.1.zip",
     "compatibility": {
         "minimum": "13.346",
-        "verified": "13.346"
+        "verified": "13"
     },
     "url": "https://github.com/vkdolea/age-system",
     "manifest": "https://raw.githubusercontent.com/vkdolea/age-system/prep-release/system.json",

--- a/templates/age-tracker.hbs
+++ b/templates/age-tracker.hbs
@@ -1,5 +1,5 @@
 {{#with system}}
-<div class="colorset-{{colorset}} flexcol age-opacity-hover flex-align-center" id="age-tracker">
+<div class="colorset-{{colorset}} flexcol age-opacity-hover flex-align-center">
     {{!-- Serendipity Tracker --}}
     {{#if hasSerendipity}}
     <div class="age-serendipity colorset-second-tier flexrow">


### PR DESCRIPTION
* Overrides _insertElement to insert into the ui-bottom container
* Removes inline positioning from the element and improves positioning relative to the hotbar.
* Explicitly enable pointer-events for the element now that the element is in a ui container.
* Removes duplicate id in the age-tracker template.

This fixes an issue where the container for the age tracker covered a
large portion of the canvas, preventing mouse interaction in those
areas.

This has been tested in both Chrome and Firefox.
